### PR TITLE
Allow the user to amend the release notes before submission. Fixes #13.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,9 @@
         "herrera-io/version": "~1.1",
         "gregwar/cache": "~1.0",
         "symfony/console": "~2.4",
-        "nubs/random-name-generator": "~0.1.0"
+        "nubs/random-name-generator": "~0.1.0",
+        "symfony/process": "~2.4",
+        "nubs/sensible": "~0.1.0"
     },
     "bin": ["bin/buildRelease"],
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -3,7 +3,7 @@
         "This file locks the dependencies of your project to a known state",
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file"
     ],
-    "hash": "c27dff3c81a700117f8aae16fc6a1ee6",
+    "hash": "7c66dc1e29c37cd42de19acfacef8629",
     "packages": [
         {
             "name": "gregwar/cache",
@@ -300,6 +300,57 @@
             "time": "2014-05-22 01:43:40"
         },
         {
+            "name": "nubs/sensible",
+            "version": "v0.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nubs/sensible.git",
+                "reference": "274f4ccfb021123eb00b06b61ba518ba89c34749"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nubs/sensible/zipball/274f4ccfb021123eb00b06b61ba518ba89c34749",
+                "reference": "274f4ccfb021123eb00b06b61ba518ba89c34749",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "suggest": {
+                "brianium/habitat": "For better access to environment variables (e.g., for mocking)."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Nubs\\Sensible\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Spencer Rinehart",
+                    "email": "anubis@overthemonkey.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A library for finding sensible user programs, like editor, pager, and browser.",
+            "keywords": [
+                "browser",
+                "editor",
+                "environment",
+                "pager",
+                "sensible",
+                "user"
+            ],
+            "time": "2014-05-28 23:13:37"
+        },
+        {
             "name": "symfony/console",
             "version": "v2.4.5",
             "target-dir": "Symfony/Component/Console",
@@ -409,6 +460,55 @@
             "description": "Symfony EventDispatcher Component",
             "homepage": "http://symfony.com",
             "time": "2014-04-16 10:34:31"
+        },
+        {
+            "name": "symfony/process",
+            "version": "v2.4.5",
+            "target-dir": "Symfony/Component/Process",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/Process.git",
+                "reference": "a7118cb290c62068b3c8ecfbf8b2eda8421fb841"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/Process/zipball/a7118cb290c62068b3c8ecfbf8b2eda8421fb841",
+                "reference": "a7118cb290c62068b3c8ecfbf8b2eda8421fb841",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Symfony\\Component\\Process\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com",
+                    "homepage": "http://fabien.potencier.org",
+                    "role": "Lead Developer"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "http://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Process Component",
+            "homepage": "http://symfony.com",
+            "time": "2014-05-22 13:46:01"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
Often enough, the release notes generated need a little modification.
For example, perhaps they don't have enough information in just the pull
request title to make informative release notes of.

This will now pop up the user's preferred editor to allow them to edit
the release notes in a freeform manner.
