### PR TITLE
Use the previous release on the same branch as the default.

### DIFF
--- a/src/BuildRelease.php
+++ b/src/BuildRelease.php
@@ -55,7 +55,7 @@ class BuildRelease extends Command
 
         $client = GithubClient::createWithToken($this->_getToken($input, $output), $owner, $repo);
 
-        $tagName = $this->_getBaseTagName($input, $output, $client);
+        $tagName = $this->_getBaseTagName($input, $output, $client, $targetBranch);
 
         $currentVersion = null;
         $commits = [];
@@ -112,9 +112,10 @@ class BuildRelease extends Command
      * @param \Symfony\Component\Console\Input\InputInterface $input The command input.
      * @param \Symfony\Component\Console\Output\OutputInterface $output The command output.
      * @param \Guywithnose\ReleaseNotes\GithubClient $client The github client.
+     * @param string $releaseBranch The branch to find releases on, or null to find tag from any branch.
      * @return string The github access token.
      */
-    private function _getBaseTagName(InputInterface $input, OutputInterface $output, GithubClient $client)
+    private function _getBaseTagName(InputInterface $input, OutputInterface $output, GithubClient $client, $releaseBranch)
     {
         $tag = $input->getOption('previous-tag-name');
         if ($tag) {
@@ -122,7 +123,7 @@ class BuildRelease extends Command
         }
 
         $dialog = $this->getHelperSet()->get('dialog');
-        $latestTag = $client->getLatestReleaseTagName();
+        $latestTag = $client->getLatestReleaseTagName($releaseBranch);
 
         return $dialog->ask($output, "<question>Please enter the base tag</question> <info>(default: {$latestTag})</info>: ", $latestTag);
     }

--- a/src/GithubClient.php
+++ b/src/GithubClient.php
@@ -48,13 +48,20 @@ class GithubClient
     /**
      * Get the latest release's tag name for the repo.
      *
+     * @param string $releaseBranch The branch to find releases on, or null to find tag from any branch.
      * @return string|null The release's tag name if one exists.
      */
-    public function getLatestReleaseTagName()
+    public function getLatestReleaseTagName($releaseBranch = null)
     {
         $releases = $this->_client->api('repo')->releases()->all($this->_owner, $this->_repo);
 
-        return empty($releases) ? null : $releases[0]['tag_name'];
+        foreach ($releases as $release) {
+            if ($releaseBranch === null || $release['target_commitish'] === $releaseBranch) {
+                return $release['tag_name'];
+            }
+        }
+
+        return null;
     }
 
     /**


### PR DESCRIPTION
Releases are targetted to a branch.  This means that if we know the base
branch (via --target-branch) then we can use that to find the most
recent release for that branch.
