### PR TITLE
Allow the user to specify the GitHub API base url.  Fixes #42.

### DIFF
--- a/src/BuildRelease.php
+++ b/src/BuildRelease.php
@@ -36,7 +36,8 @@ class BuildRelease extends Command
             ->addOption('release-version', 'R', InputOption::VALUE_REQUIRED, 'The version number to release')
             ->addOption('access-token', 't', InputOption::VALUE_REQUIRED, 'The access token to use (overrides cache)')
             ->addOption('cache-dir', null, InputOption::VALUE_REQUIRED, 'The access token cache location', dirname(__DIR__))
-            ->addOption('token-file', null, InputOption::VALUE_REQUIRED, 'The access token cache filename', '.access_token');
+            ->addOption('token-file', null, InputOption::VALUE_REQUIRED, 'The access token cache filename', '.access_token')
+            ->addOption('github-api', null, InputOption::VALUE_REQUIRED, 'The base url to the GitHub API');
     }
 
     /**
@@ -55,7 +56,7 @@ class BuildRelease extends Command
         $repo = $input->getArgument('repo-name');
         $targetBranch = $input->getOption('target-branch');
 
-        $client = GithubClient::createWithToken($this->_getToken($input, $promptFactory), $owner, $repo);
+        $client = GithubClient::createWithToken($this->_getToken($input, $promptFactory), $owner, $repo, $input->getOption('github-api'));
 
         $tagName = $this->_getBaseTagName($input, $promptFactory, $client, $targetBranch);
         $currentVersion = Version::createFromString($tagName);;

--- a/src/GithubClient.php
+++ b/src/GithubClient.php
@@ -35,11 +35,17 @@ class GithubClient
      * @param string $token The API token to authenticate with.
      * @param string $owner The owner name of the github repository.
      * @param string $repo The name of the github repository.
+     * @param string $apiUrl The base url to the github API if different from the main github site (i.e., GitHub Enterprise).
      * @return self The github client wrapper, authenticated against the API.
      */
-    public static function createWithToken($token, $owner, $repo)
+    public static function createWithToken($token, $owner, $repo, $apiUrl = null)
     {
         $client = new Client();
+
+        if ($apiUrl !== null) {
+            $client->setOption('base_url', $apiUrl);
+        }
+
         $client->authenticate($token, null, Client::AUTH_HTTP_TOKEN);
 
         return new static($client, $owner, $repo);


### PR DESCRIPTION
For GitHub Enterprise, the API url needs to be specified.  The default
will still use the public GitHub website's API.
