### PR TITLE
Support all kinds of merges, not just pull requests.

### DIFF
--- a/src/Change/ChangeFactory.php
+++ b/src/Change/ChangeFactory.php
@@ -29,11 +29,15 @@ class ChangeFactory
     {
         $typeSelector = $this->_typeSelector;
 
-        if (
-            count($commit['parents']) === 2 &&
-            preg_match('/Merge pull request #([0-9]*)[^\n]*\n[^\n]*\n(.*)/s', $commit['commit']['message'], $matches)
-        ) {
-            $change = new PullRequest((int)$matches[1], $matches[2]);
+        if (count($commit['parents']) > 1) {
+            $change = null;
+            if (preg_match('/Merge pull request #([0-9]*)[^\n]*\n[^\n]*\n(.*)/s', $commit['commit']['message'], $matches)) {
+                $change = new PullRequest((int)$matches[1], $matches[2]);
+            } elseif (preg_match('/Merge branch \'([^\']*)\'[^\n]*\n[^\n]*\n(.*)/s', $commit['commit']['message'], $matches)) {
+                $change = new Merge($matches[1], $matches[2]);
+            } else {
+                $change = new Change($commit['commit']['message']);
+            }
 
             $type = $typeSelector($change);
             if ($type === Change::TYPE_IGNORE) {

--- a/src/Change/Merge.php
+++ b/src/Change/Merge.php
@@ -1,0 +1,42 @@
+<?php
+namespace Guywithnose\ReleaseNotes\Change;
+
+class Merge extends Change
+{
+    /** @type string The branch name. */
+    protected $_branch;
+
+    /**
+     * Create the merge change.
+     *
+     * @api
+     * @param string $branch The merged branch.
+     * @param string $message The merge message.
+     * @param string $type The merge type.  @see \Guywithnose\ReleaseNotes\Change::types().
+     */
+    public function __construct($branch, $message, $type = null)
+    {
+        parent::__construct($message, $type);
+        $this->_branch = $branch;
+    }
+
+    /**
+     * Returns a short markdown snippet of the merge for use in release notes.
+     *
+     * @return string A short representation of the merge.
+     */
+    public function displayShort()
+    {
+        return parent::displayShort() . "&nbsp;<sup>[{$this->_branch}]</sup>";
+    }
+
+    /**
+     * Returns a long markdown version of the merge for use in user display.
+     *
+     * @return string A long representation of the merge.
+     */
+    public function displayFull()
+    {
+        return "### {$this->_branch}\n{$this->_message}";
+    }
+}


### PR DESCRIPTION
Merges also work as a nice toplevel block of change even if they don't
have as strong of an appearance on GitHub.  Their messages are often
unhelpful, but that isn't necessarily the case so it makes sense to
still look at them.

This partially addresses #23.
