### PR TITLE
Dynamically find the user's editor across full PATH.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
         "symfony/console": "~2.4",
         "nubs/random-name-generator": "~0.1.0",
         "symfony/process": "~2.4",
-        "nubs/sensible": "~0.3.0"
+        "nubs/sensible": "~0.3.0",
+        "nubs/which": "~1.0"
     },
     "bin": ["bin/buildRelease"],
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "0b0f6dc4a080c4bc7dce1d71194b0742",
+    "hash": "9f8477058484050cff0ec2bdaef46ccf",
     "packages": [
         {
             "name": "gregwar/cache",
@@ -353,6 +353,59 @@
                 "user"
             ],
             "time": "2014-07-07 00:08:17"
+        },
+        {
+            "name": "nubs/which",
+            "version": "v1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nubs/which.git",
+                "reference": "888d271d3776b7d989698b5e045aa269db29c47e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nubs/which/zipball/888d271d3776b7d989698b5e045aa269db29c47e",
+                "reference": "888d271d3776b7d989698b5e045aa269db29c47e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~5.4"
+            },
+            "require-dev": {
+                "brianium/habitat": "~1.0",
+                "phpunit/phpunit": "~4.0",
+                "squizlabs/php_codesniffer": "~1.5"
+            },
+            "suggest": {
+                "brianium/habitat": "For better access to environment variables (e.g., for mocking)."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Nubs\\Which\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Spencer Rinehart",
+                    "email": "anubis@overthemonkey.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A library for locating commands in a PATH.",
+            "keywords": [
+                "executable",
+                "linux",
+                "path",
+                "script",
+                "which",
+                "windows"
+            ],
+            "time": "2014-07-10 00:07:25"
         },
         {
             "name": "symfony/console",

--- a/src/BuildRelease.php
+++ b/src/BuildRelease.php
@@ -9,6 +9,7 @@ use Guywithnose\ReleaseNotes\Change\ChangeListFactory;
 use Guywithnose\ReleaseNotes\Prompt\PromptFactory;
 use Nubs\RandomNameGenerator\Vgng;
 use Nubs\Sensible\Editor;
+use Nubs\Which\LocatorFactory\PlatformLocatorFactory as WhichLocatorFactory;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Formatter\OutputFormatterStyle;
 use Symfony\Component\Console\Input\InputArgument;
@@ -72,10 +73,14 @@ class BuildRelease extends Command
             return 1;
         }
 
+        $commandLocatorFactory = new WhichLocatorFactory();
+        $editor = new Editor(['commandLocator' => $commandLocatorFactory->create()]);
+
         $suggestedVersions = $this->_getSuggestedNewVersions($currentVersion, $changes);
         $newVersion = $this->_getVersion($input, $promptFactory, $currentVersion, $suggestedVersions);
         $releaseName = $this->_getReleaseName($input, $promptFactory);
-        $releaseNotes = $this->_amendReleaseNotes($input, new Editor(), new ProcessBuilder(), $changes->display());
+
+        $releaseNotes = $this->_amendReleaseNotes($input, $editor, new ProcessBuilder(), $changes->display());
 
         $release = $this->_buildRelease($newVersion, $releaseName, $releaseNotes, $targetBranch);
         $this->_submitRelease($promptFactory, $client, $release);


### PR DESCRIPTION
Sensible provides command lookup support via the which library.  This means that the user's editor will be found on more systems assuming they have a proper PATH set up.
