### PR TITLE
Allow for non-semantic versions.

### DIFF
--- a/src/BuildRelease.php
+++ b/src/BuildRelease.php
@@ -141,6 +141,9 @@ class BuildRelease extends Command
     {
         $largestChangeType = $changes->largestChange()->getType();
         $increments = $currentVersion->getSemanticIncrements();
+        if (empty($increments)) {
+            return [];
+        }
 
         if ($largestChangeType === Change::TYPE_BC) {
             return [$increments['major'], $increments['minor'], $increments['patch']];
@@ -172,7 +175,13 @@ class BuildRelease extends Command
         }
 
         return Version::createFromString(
-            $promptFactory->invoke("Version Number (current: {$currentVersion})", $suggestedVersions[0], $suggestedVersions, null, false)
+            $promptFactory->invoke(
+                "Version Number (current: {$currentVersion})",
+                empty($suggestedVersions) ? null : $suggestedVersions[0],
+                $suggestedVersions,
+                null,
+                false
+            )
         );
     }
 

--- a/src/Version.php
+++ b/src/Version.php
@@ -5,22 +5,36 @@ use Herrera\Version\Builder as VersionBuilder;
 use Herrera\Version\Dumper as VersionDumper;
 use Herrera\Version\Parser as VersionParser;
 use Herrera\Version\Version as HerreraVersion;
+use Herrera\Version\Exception\InvalidStringRepresentationException;
 
 class Version
 {
+    /** @type string The version as a string. */
+    protected $_versionString;
+
     /** @type \Herrera\Version\Version The version. */
     protected $_version;
+
+    /** @type boolean Whether the version is a semantic version. */
+    protected $_isSemantic;
 
     /**
      * Initialize the version.
      *
      * If the version is not given, a 0.0.0 version is assumed.
      *
-     * @param \Herrera\Version\Version The version.
+     * @param string The version.
      */
-    public function __construct(HerreraVersion $version = null)
+    public function __construct($version = null)
     {
-        $this->_version = $version ?: new HerreraVersion();
+        $this->_versionString = $version ?: '0.0.0';
+
+        try {
+            $this->_version = VersionParser::toVersion($this->_versionString);
+            $this->_isSemantic = true;
+        } catch (InvalidStringRepresentationException $e) {
+            $this->_isSemantic = false;
+        }
     }
 
     /**
@@ -33,18 +47,20 @@ class Version
      */
     public static function createFromString($string)
     {
-        $version = $string ? VersionParser::toVersion(ltrim($string, 'v')) : null;
-
-        return new static($version);
+        return new static(ltrim($string, 'v'));
     }
 
     /**
      * Get the possible ways to increment the version using semantic versioning.
      *
-     * @return array The semantic version number increments.
+     * @return array The semantic version number increments.  Will be empty for non-semantic versions.
      */
     public function getSemanticIncrements()
     {
+        if (!$this->_isSemantic) {
+            return [];
+        }
+
         $builder = VersionBuilder::create()->importVersion($this->_version);
         $builder->clearBuild();
         $builder->clearPreRelease();
@@ -63,7 +79,7 @@ class Version
      */
     public function isPreRelease()
     {
-        return !$this->_version->isStable();
+        return !$this->_isSemantic || !$this->_version->isStable();
     }
 
     /**
@@ -83,6 +99,6 @@ class Version
      */
     public function __toString()
     {
-        return (string)$this->_version;
+        return $this->_isSemantic ? (string)$this->_version : $this->_versionString;
     }
 }


### PR DESCRIPTION
Sometimes you end up with versions that aren't semantic.  This makes it
easier to use those as the basis for new versions and for creating
non-semantic versions using this tool.