### PR TITLE
Don't die when there are no new commits after base tag.

### DIFF
--- a/src/GithubCommitGraph.php
+++ b/src/GithubCommitGraph.php
@@ -28,7 +28,7 @@ class GithubCommitGraph
         $result = [];
 
         $current = $this->_baseCommitNode();
-        while ($current->getAttribute('commit')) {
+        while ($current !== null && $current->getAttribute('commit')) {
             $result[] = $current->getAttribute('commit');
             $parents = $current->getVerticesEdgeTo();
             if ($parents->isEmpty()) {
@@ -67,7 +67,7 @@ class GithubCommitGraph
     /**
      * Searches the graph for the base commit node.
      *
-     * @return \Fhaculty\Graph\Vertex The base commit node.
+     * @return \Fhaculty\Graph\Vertex|null The base commit node or null if there isn't exactly one.
      */
     private function _baseCommitNode()
     {
@@ -75,6 +75,8 @@ class GithubCommitGraph
             return $vertex->getEdgesIn()->isEmpty();
         };
 
-        return $this->_graph->getVertices()->getVertexMatch($noChildren);
+        $baseNodes = $this->_graph->getVertices()->getVerticesMatch($noChildren);
+
+        return $baseNodes->count() === 1 ? $baseNodes->getVertexFirst() : null;
     }
 }


### PR DESCRIPTION
When there are no commits since the last tag at all and the graph is empty, this code was erroring when trying to call `getVertexMatch` (none would match).  This updates it to use `getVerticesMatch` instead which returns a set of vertices that match and doesn't error when there are none.  This was done to be safest to all possible graphs.  Cyclic graphs (which shouldn't occur) would have no matches and would be treated the same as an empty graph.  The other possibility that wasn't treated before was when there are multiple commits with no children (which shouldn't happen).  This will now also act the same as an empty graph. This is implemented by just checking the count of commits with no children and if we don't find exactly one commit like that, return null for the base commit, otherwise return that single commit.

The `firstParents` method also had to be updated to handle this `null` value.  By handling it in the `while` loop condition, we protect ourselves for any potential cases where `$current` gets set to `null` in the loop as well.  The behavior in either of these cases would be to break out of the loop and return the array so far.  For 0-commit graphs, this would return an empty array as expected.

The calling code already knows how to handle an empty array of commits and rather than erroring out like was happening, it now prints a message saying "There were no unreleased changes found!" like expected.