### PR TITLE
Upgrade from the DialogHelper to the QuestionHelper.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "knplabs/github-api": "~1.2",
         "herrera-io/version": "~1.1",
         "gregwar/cache": "~1.0",
-        "symfony/console": "~2.4",
+        "symfony/console": "~2.7",
         "nubs/random-name-generator": "~0.1.0",
         "symfony/process": "~2.4",
         "nubs/sensible": "~0.4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "1cfd6ba4cab17d23660cf94be0ef0864",
+    "hash": "e60ce10d9bb8f1ce40c25070971b8c3e",
     "packages": [
         {
             "name": "clue/graph",
@@ -458,16 +458,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v2.7.2",
+            "version": "v2.7.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Console.git",
-                "reference": "8cf484449130cabfd98dcb4694ca9945802a21ed"
+                "reference": "d6cf02fe73634c96677e428f840704bfbcaec29e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Console/zipball/8cf484449130cabfd98dcb4694ca9945802a21ed",
-                "reference": "8cf484449130cabfd98dcb4694ca9945802a21ed",
+                "url": "https://api.github.com/repos/symfony/Console/zipball/d6cf02fe73634c96677e428f840704bfbcaec29e",
+                "reference": "d6cf02fe73634c96677e428f840704bfbcaec29e",
                 "shasum": ""
             },
             "require": {
@@ -511,11 +511,11 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2015-07-09 16:07:40"
+            "time": "2015-07-28 15:18:12"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v2.7.2",
+            "version": "v2.7.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/EventDispatcher.git",
@@ -573,7 +573,7 @@
         },
         {
             "name": "symfony/process",
-            "version": "v2.7.2",
+            "version": "v2.7.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Process.git",

--- a/src/BuildRelease.php
+++ b/src/BuildRelease.php
@@ -57,10 +57,9 @@ class BuildRelease extends Command
 
         $owner = $input->getArgument('repo-owner');
         $repo = $input->getArgument('repo-name');
-        $targetBranch = $input->getOption('target-branch');
-        $isDraft = !$input->getOption('publish');
-
         $client = GithubClient::createWithToken($this->_getToken($input, $promptFactory), $owner, $repo, $input->getOption('github-api'));
+
+        $targetBranch = $input->getOption('target-branch');
 
         $tagName = $this->_getBaseTagName($input, $promptFactory, $client, $targetBranch);
         $currentVersion = Version::createFromString($tagName);
@@ -88,6 +87,7 @@ class BuildRelease extends Command
         $editor = $editorFactory->create();
         $releaseNotes = $this->_amendReleaseNotes($input, $editor, new ProcessBuilder(), $changes->display());
 
+        $isDraft = !$input->getOption('publish');
         $release = $this->_buildRelease($newVersion, $releaseName, $releaseNotes, $targetBranch, $isDraft);
         $this->_submitRelease($promptFactory, $client, $release);
     }

--- a/src/BuildRelease.php
+++ b/src/BuildRelease.php
@@ -55,9 +55,12 @@ class BuildRelease extends Command
         $output->getFormatter()->setStyle('boldquestion', new OutputFormatterStyle('red', 'cyan', ['bold']));
         $promptFactory = new PromptFactory($output, $this->getHelperSet()->get('dialog'), $this->getHelperSet()->get('formatter'));
 
-        $owner = $input->getArgument('repo-owner');
-        $repo = $input->getArgument('repo-name');
-        $client = GithubClient::createWithToken($this->_getToken($input, $promptFactory), $owner, $repo, $input->getOption('github-api'));
+        $client = GithubClient::createWithToken(
+            $this->_getToken($input, $promptFactory),
+            $input->getArgument('repo-owner'),
+            $input->getArgument('repo-name'),
+            $input->getOption('github-api')
+        );
 
         $targetBranch = $input->getOption('target-branch');
 

--- a/src/BuildRelease.php
+++ b/src/BuildRelease.php
@@ -53,7 +53,7 @@ class BuildRelease extends Command
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $output->getFormatter()->setStyle('boldquestion', new OutputFormatterStyle('red', 'cyan', ['bold']));
-        $promptFactory = new PromptFactory($output, $this->getHelperSet()->get('dialog'), $this->getHelperSet()->get('formatter'));
+        $promptFactory = new PromptFactory($input, $output, $this->getHelperSet()->get('question'), $this->getHelperSet()->get('formatter'));
 
         $client = GithubClient::createWithToken(
             $this->_getToken($input, $promptFactory),

--- a/src/Change/Change.php
+++ b/src/Change/Change.php
@@ -3,7 +3,7 @@ namespace Guywithnose\ReleaseNotes\Change;
 
 class Change
 {
-    const TYPE_BC = 'bc';
+    const TYPE_BC = 'B';
     const TYPE_MAJOR = 'M';
     const TYPE_MINOR = 'm';
     const TYPE_BUGFIX = 'b';

--- a/src/Change/ChangeFactory.php
+++ b/src/Change/ChangeFactory.php
@@ -14,9 +14,11 @@ class ChangeFactory
      *
      * @param callable $typeSelector The type selector function.
      */
-    public function __construct(callable $typeSelector)
+    public function __construct(callable $typeSelector = null)
     {
-        $this->_typeSelector = $typeSelector;
+        $this->_typeSelector = $typeSelector ?: function(Change $change) {
+            return $change->getType();
+        };
     }
 
     /**

--- a/src/Prompt/PromptFactory.php
+++ b/src/Prompt/PromptFactory.php
@@ -1,17 +1,21 @@
 <?php
 namespace Guywithnose\ReleaseNotes\Prompt;
 
-use Symfony\Component\Console\Helper\DialogHelper;
+use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Helper\FormatterHelper;
+use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class PromptFactory
 {
+    /** @type \Symfony\Component\Console\Input\InputInterface The command output. */
+    protected $_input;
+
     /** @type \Symfony\Component\Console\Output\OutputInterface The command output. */
     protected $_output;
 
-    /** @type \Symfony\Component\Console\Helper\DialogHelper The dialog helper. */
-    protected $_dialog;
+    /** @type \Symfony\Component\Console\Helper\QuestionHelper The question helper. */
+    protected $_questionHelper;
 
     /** @type \Symfony\Component\Console\Helper\FormatterHelper The formatter helper. */
     protected $_formatter;
@@ -19,14 +23,16 @@ class PromptFactory
     /**
      * Initialize the prompt factory.
      *
+     * @param \Symfony\Component\Console\Input\InputInterface $input The command input.
      * @param \Symfony\Component\Console\Output\OutputInterface $output The command output.
-     * @param \Symfony\Component\Console\Helper\DialogHelper $dialog The dialog helper.
+     * @param \Symfony\Component\Console\Helper\QuestionHelper $questionHelper The question helper.
      * @param \Symfony\Component\Console\Helper\FormatterHelper $formatter The formatter helper.
      */
-    public function __construct(OutputInterface $output, DialogHelper $dialog, FormatterHelper $formatter)
+    public function __construct(InputInterface $input, OutputInterface $output, QuestionHelper $questionHelper, FormatterHelper $formatter)
     {
+        $this->_input = $input;
         $this->_output = $output;
-        $this->_dialog = $dialog;
+        $this->_questionHelper = $questionHelper;
         $this->_formatter = $formatter;
     }
 
@@ -42,7 +48,17 @@ class PromptFactory
      */
     public function create($question, $default = null, array $choices = [], $preamble = '', $choicesOnly = true)
     {
-        return new Prompt($this->_output, $this->_dialog, $this->_formatter, $question, $default, $choices, $preamble, $choicesOnly);
+        return new Prompt(
+            $this->_input,
+            $this->_output,
+            $this->_questionHelper,
+            $this->_formatter,
+            $question,
+            $default,
+            $choices,
+            $preamble,
+            $choicesOnly
+        );
     }
 
     /**


### PR DESCRIPTION
Symphony has deprecated the DialogHelper and replaced it with a new QuestionHelper.  This updates the code to use the newer helper without otherwise changing behavior.

Because of how the new QuestionHelper is created, we now need to pass the InputInterface through to the prompt.  This is the cause of most of the changes in the code.

Because the QuestionHelper is newish, I also bumped the required symphony/console version up to 2.7.

This also includes a couple other commits that I started on for some bigger changes I am working on.  I can remove these if they aren't wanted right now, but they are pretty simple little refactoring-like things so far.