### PR TITLE
Change primary UI to a menu loop.

### DIFF
--- a/src/BuildRelease.php
+++ b/src/BuildRelease.php
@@ -121,7 +121,7 @@ class BuildRelease extends Command
      * @param \Guywithnose\ReleaseNotes\Prompt\PromptFactory $promptFactory The prompt factory.
      * @param \Guywithnose\ReleaseNotes\GithubClient $client The github client.
      * @param string $releaseBranch The branch to find releases on, or null to find tag from any branch.
-     * @return string The github access token.
+     * @return string The base tag name.
      */
     private function _getBaseTagName(InputInterface $input, PromptFactory $promptFactory, GithubClient $client, $releaseBranch)
     {

--- a/src/BuildRelease.php
+++ b/src/BuildRelease.php
@@ -144,11 +144,13 @@ class BuildRelease extends Command
      */
     private function _getSuggestedNewVersions(Version $currentVersion, ChangeList $changes)
     {
-        $largestChangeType = $changes->largestChange()->getType();
         $increments = $currentVersion->getSemanticIncrements();
         if (empty($increments)) {
             return [];
         }
+
+        $largestChange = $changes->largestChange();
+        $largestChangeType = $largestChange ? $largestChange->getType() : Change::TYPE_MINOR;
 
         if ($largestChangeType === Change::TYPE_BC) {
             return [$increments['major'], $increments['minor'], $increments['patch']];

--- a/src/BuildRelease.php
+++ b/src/BuildRelease.php
@@ -65,7 +65,7 @@ class BuildRelease extends Command
         $targetBranch = $input->getOption('target-branch');
 
         $tagName = $this->_getBaseTagName($input, $promptFactory, $client, $targetBranch);
-        $currentVersion = Version::createFromString($tagName);
+        $currentVersion = new Version($tagName);
 
         $selectTypeForChange = function(Change $change) use($promptFactory) {
             return $this->_selectTypeForChange($promptFactory, $change);
@@ -178,10 +178,10 @@ class BuildRelease extends Command
     {
         $version = $input->getOption('release-version');
         if ($version) {
-            return Version::createFromString($version);
+            return new Version($version);
         }
 
-        return Version::createFromString(
+        return new Version(
             $promptFactory->invoke(
                 "Version Number (current: {$currentVersion})",
                 empty($suggestedVersions) ? null : $suggestedVersions[0],

--- a/src/Release.php
+++ b/src/Release.php
@@ -55,7 +55,7 @@ class Release
      */
     public function previewFormat()
     {
-        return "{$this->_releaseName()}\n\n{$this->notes}";
+        return implode([$this->_actionDescription(), $this->_releaseName(), $this->notes], "\n\n");
     }
 
     /**
@@ -83,5 +83,17 @@ class Release
     protected function _releaseName()
     {
         return "Version {$this->version}" . ($this->name ? ": {$this->name}" : '');
+    }
+
+    /**
+     * Builds a description of the action being taken by this release.
+     *
+     * @return string The formatted action description.
+     */
+    protected function _actionDescription()
+    {
+        $action = $this->isDraft ? 'Drafting' : 'Publishing';
+        $releaseType = $this->version->isPreRelease() ? 'pre-release' : 'release';
+        return "{$action} {$releaseType} tag on {$this->targetCommitish}.";
     }
 }

--- a/src/Release.php
+++ b/src/Release.php
@@ -1,0 +1,87 @@
+<?php
+namespace Guywithnose\ReleaseNotes;
+
+use Guywithnose\ReleaseNotes\Change\ChangeList;
+
+class Release
+{
+    /** @type \Guywithnose\ReleaseNotes\Change\ChangeList The changes made for this release. */
+    public $changes;
+
+    /** @type \Guywithnose\ReleaseNotes\Version The version of the previous release. */
+    public $currentVersion;
+
+    /** @type \Guywithnose\ReleaseNotes\Version The version of the release. */
+    public $version;
+
+    /** @type string The name of the release. */
+    public $name;
+
+    /** @type string The formatted release notes. */
+    public $notes;
+
+    /** @type string The target commit/branch/etc. to tag. */
+    public $targetCommitish;
+
+    /** @type boolean Whether the release is a draft or if it should be published immediately. */
+    public $isDraft;
+
+    /**
+     * Initialize the release.
+     *
+     * @param \Guywithnose\ReleaseNotes\Change\ChangeList $changes The changes made for this release.
+     * @param \Guywithnose\ReleaseNotes\Version $version The version of the previous release.
+     * @param \Guywithnose\ReleaseNotes\Version $version The version of the release.
+     * @param string $name The name of the release.
+     * @param string $notes The formatted release notes.
+     * @param string $targetCommitish The target commit/branch/etc. to tag.
+     * @param boolean $isDraft Whether the release is a draft or if it should be published immediately.
+     */
+    public function __construct(ChangeList $changes, Version $currentVersion, Version $version, $name, $notes, $targetCommitish, $isDraft)
+    {
+        $this->changes = $changes;
+        $this->currentVersion = $currentVersion;
+        $this->version = $version;
+        $this->name = $name;
+        $this->notes = $notes;
+        $this->targetCommitish = $targetCommitish;
+        $this->isDraft = $isDraft;
+    }
+
+    /**
+     * Builds a preview of the release for display to the user.
+     *
+     * @return string A preview of the release.
+     */
+    public function previewFormat()
+    {
+        return "{$this->_releaseName()}\n\n{$this->notes}";
+    }
+
+    /**
+     * Builds the release information to send to github.
+     *
+     * @return array The data to send to github.
+     */
+    public function githubFormat()
+    {
+        return [
+            'tag_name' => $this->version->tagName(),
+            'name' => $this->_releaseName(),
+            'body' => $this->notes,
+            'prerelease' => $this->version->isPreRelease(),
+            'draft' => $this->isDraft,
+            'target_commitish' => $this->targetCommitish,
+        ];
+    }
+
+    /**
+     * Returns the formatted name of the GitHub release, including version.
+     *
+     * @return string The formatted release name.
+     */
+    protected function _releaseName()
+    {
+        return "Version {$this->version}" . ($this->name ? ": {$this->name}" : '');
+    }
+}

--- a/src/Version.php
+++ b/src/Version.php
@@ -27,27 +27,14 @@ class Version
      */
     public function __construct($version = null)
     {
-        $this->_versionString = $version ?: '0.0.0';
+        $this->_versionString = $version ?: 'v0.0.0';
 
         try {
-            $this->_version = VersionParser::toVersion($this->_versionString);
+            $this->_version = VersionParser::toVersion(ltrim($this->_versionString, 'v'));
             $this->_isSemantic = true;
         } catch (InvalidStringRepresentationException $e) {
             $this->_isSemantic = false;
         }
-    }
-
-    /**
-     * Create the version from a string.
-     *
-     * The string will have any leading 'v' trimmed off of it.
-     *
-     * @param string $string The version with an optional leading v.
-     * @return self The version object.
-     */
-    public static function createFromString($string)
-    {
-        return new static(ltrim($string, 'v'));
     }
 
     /**

--- a/src/Version.php
+++ b/src/Version.php
@@ -88,4 +88,14 @@ class Version
     {
         return $this->_isSemantic ? (string)$this->_version : $this->_versionString;
     }
+
+    /**
+     * Returns the unprocessed version string directly.
+     *
+     * @return string The version string used to construct this version.
+     */
+    public function unprocessed()
+    {
+        return $this->_versionString;
+    }
 }


### PR DESCRIPTION
This is a major change of the UI to a loop that asks you to choose what step to take.  You can revisit previous steps and tweak things until the release notes are finalized.

The proposed reasons for this change:
* It was super annoying when you answered a prompt incorrectly before as there was no way to go back and fix it without restarting from the beginning.
* Adding new features with new prompts was becoming very difficult and made the tool even harder to use with each new prompt.  By pulling things down into a simple loop, adding new choices or beefing out the existing choices is made easier.
* There were a lot of prompts in the old UI that you generally went with the default answer on.  These prompts can be skipped entirely now.

The diff for this is nasty, as is some of the code.  It was difficult to find a way of introducing this change without making a massive amount of changes, but I tried to pull out as much as I could.