### PR TITLE
Add option to only include Pull Request commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Release Notes builer tool
+# Release Notes builder tool
 
 Look at the commits on a github repo and generate release notes using the
 commits that have occurred since the last tag.

--- a/src/BuildRelease.php
+++ b/src/BuildRelease.php
@@ -8,6 +8,7 @@ use Guywithnose\ReleaseNotes\Change\ChangeList;
 use Guywithnose\ReleaseNotes\Change\ChangeListFactory;
 use Guywithnose\ReleaseNotes\Prompt\PromptFactory;
 use Guywithnose\ReleaseNotes\Type\JiraTypeSelector;
+use Guywithnose\ReleaseNotes\Type\PullRequestTypeSelector;
 use Guywithnose\ReleaseNotes\Type\Type;
 use Guywithnose\ReleaseNotes\Type\TypeManager;
 use JiraRestApi\Issue\IssueService;
@@ -91,6 +92,11 @@ class BuildRelease extends Command
             InputOption::VALUE_REQUIRED,
             'Specify the number of levels to look for commits.',
             1
+        )->addOption(
+            'pull-requests-only',
+            null,
+            InputOption::VALUE_NONE,
+            'Only include Pull Requests in the change list.'
         )->addOption('cache-dir', null, InputOption::VALUE_REQUIRED, 'The access token cache location', dirname(__DIR__))->addOption(
             'token-file',
             null,
@@ -270,6 +276,11 @@ class BuildRelease extends Command
             $issueService = new IssueService();
             $jiraTypeSelector = new JiraTypeSelector($this->typeManager, $issueService, '/\w+-\d+/', $output);
             $typeSelector = [$jiraTypeSelector, 'getChangeType'];
+        }
+
+        if ($input->getOption('pull-requests-only')) {
+            $prTypeSelector = new PullRequestTypeSelector($this->typeManager, $typeSelector);
+            $typeSelector = [$prTypeSelector, 'getChangeType'];
         }
 
         $changes = $this->_getChangesInRange($input, $client, $baseTagName, $targetBranch, $typeSelector);

--- a/src/Type/PullRequestTypeSelector.php
+++ b/src/Type/PullRequestTypeSelector.php
@@ -1,0 +1,49 @@
+<?php
+namespace Guywithnose\ReleaseNotes\Type;
+
+use Guywithnose\ReleaseNotes\Change\Change;
+use Guywithnose\ReleaseNotes\Change\ChangeInterface;
+use Guywithnose\ReleaseNotes\Change\PullRequest;
+
+final class PullRequestTypeSelector
+{
+    /**
+     * @type TypeManager type manager with the specified types
+     */
+    private $_typeManager;
+
+    /**
+     * @type callable Type selector callable to call when change is a Pull Request
+     */
+    private $_typeSelector;
+
+    /**
+     * Initialize the change.
+     *
+     * @param TypeManager $typeManager  Type name or short description.
+     * @param callable    $typeSelector Type selector callable to call when change is a Pull Request
+     */
+    public function __construct(TypeManager $typeManager, callable $typeSelector = null)
+    {
+        $this->_typeManager = $typeManager;
+        $this->_typeSelector = $typeSelector;
+    }
+
+    /**
+     * @param ChangeInterface $change Change to check for type from Jira
+     *
+     * @return Type type of commit or default if unable to determine
+     */
+    public function getChangeType(ChangeInterface $change) : Type
+    {
+        if (!$change instanceof PullRequest) {
+            return $this->_typeManager->getTypeByCode(Change::TYPE_IGNORE);
+        }
+
+        if ($this->_typeSelector) {
+            return $this->_typeSelector($change);
+        }
+
+        return $change->getType();
+    }
+}

--- a/src/Type/TypeManager.php
+++ b/src/Type/TypeManager.php
@@ -136,7 +136,7 @@ final class TypeManager
         $manager->add(new Type('Minor', 'm', 'Minor Features', 60));
         $manager->add(new Type('Bug', 'b', 'Bug Fixes', 40));
         $manager->add(new Type('Developer', 'd', 'Developer Changes', 20));
-        $manager->add(new Type('Ignore', 'x', 'Remove Pull Request from Release Notes', 0));
+        $manager->add(new Type('Ignore', 'x', 'Remove Commit from Release Notes', 0));
 
         $manager->setBCType($manager->getTypeByCode('B'));
         $manager->setMajorType($manager->getTypeByCode('M'));
@@ -157,7 +157,7 @@ final class TypeManager
         $manager->add(new Type('Bug', 'b', 'Bug fix', 40));
         $manager->add(new Type('Maintenance', 'm', 'Maintenance change', 20));
         $manager->add(new Type('Sub-task', 't', 'Sub-tasks', 10));
-        $manager->add(new Type('Ignore', 'x', 'Remove Pull Request from Release Notes', 0));
+        $manager->add(new Type('Ignore', 'x', 'Remove Commit from Release Notes', 0));
         $manager->add(new Type('Unknown', 'u', 'Unknown type/No type selected', -10));
 
         $manager->setBCType($manager->getTypeByCode('e'));


### PR DESCRIPTION
To better be able to handle generating release notes from multiple levels of merges using the github flow and feature branches I am adding a new command line option --pull-requests-only that will ignore non pull request formatted commits when building the release notes.